### PR TITLE
Add unseal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: up halt restart destroy init sync update ssh
 
 export VAGRANT_EXPERIMENTAL="dependency_provisioners"
+VAULT_UNSEAL_KEY ?= "INSERT-VAULT-UNSEAL-KEY"
+UBUNTU_VERSION ?= "20.04"
+VAGRANT_PROVIDER ?= "virtualbox"
 
 #
 # up is a shortcut to start the Vagrant environment.
@@ -59,3 +62,9 @@ ssh:
 	bolt command run "sudo mkdir -p /root/.ssh" --targets=us --run-as root
 	bolt command run "ssh-keyscan github.com | sudo tee -a /root/.ssh/known_hosts" --targets=us --run-as root
 	bolt command run "ssh-keyscan bitbucket.org | sudo tee -a /root/.ssh/known_hosts" --targets=us --run-as root
+
+#
+# unseal is a shortcut to unseal the Vault servers given a single unseal key VAULT_UNSEAL_KEY
+#
+unseal:
+	./scripts/unseal.sh $(VAULT_UNSEAL_KEY)

--- a/documentation/maintenance.md
+++ b/documentation/maintenance.md
@@ -24,6 +24,11 @@ restart the Consul, Nomad, and Vault services,  run:
 $ UBUNTU_VERSION=<version> VAULT_TOKEN=<token> make sync
 ```
 
+To unseal the Vault servers
+```bash
+$ VAULT_UNSEAL_KEY=<vault-unseal-key> make unseal
+```
+
 To completely restart the Vagrant environment, run:
 ```bash
 $ UBUNTU_VERSION=<version> VAULT_TOKEN=<token> make restart

--- a/documentation/vault-init.md
+++ b/documentation/vault-init.md
@@ -34,11 +34,17 @@ If you access the Consul UI at <http://192.168.60.10:8500>, you will note that
 Vault is still not healthy:
 ![Consul Services](../assets/consul-init-02.png)
 
-It is because you need to unseal Vault on every nodes. To achieve this, access
-the Vault UI and unseal Vault on *server* nodes via:
+It is because you need to unseal Vault on every node. To achieve this, access the Vault UI and unseal Vault on *server* nodes via:
 - <http://192.168.60.10:8200> for `eu-west-1`
 - <http://192.168.60.20:8200> for `eu-west-2`
 - <http://192.168.60.30:8200> for `eu-east-1`
+
+
+After fetching your unseal key and token from one of the Vault servers you can use the `unseal` shortcut to unseal the remainder Vault servers or subsequent unseals
+
+```bash
+$ VAULT_UNSEAL_KEY=<vault-unseal-key> make unseal
+```
 
 In Consul, we can see that every health checks are now passing and the service list
 looks like this:

--- a/documentation/vault-init.md
+++ b/documentation/vault-init.md
@@ -34,14 +34,7 @@ If you access the Consul UI at <http://192.168.60.10:8500>, you will note that
 Vault is still not healthy:
 ![Consul Services](../assets/consul-init-02.png)
 
-It is because you need to unseal Vault on every node. To achieve this, access the Vault UI and unseal Vault on *server* nodes via:
-- <http://192.168.60.10:8200> for `eu-west-1`
-- <http://192.168.60.20:8200> for `eu-west-2`
-- <http://192.168.60.30:8200> for `eu-east-1`
-
-
-After fetching your unseal key and token from one of the Vault servers you can use the `unseal` shortcut to unseal the remainder Vault servers or subsequent unseals
-
+It is because you need to unseal Vault on every node. To achieve this, you can use the `make unseal` command as follows:
 ```bash
 $ VAULT_UNSEAL_KEY=<vault-unseal-key> make unseal
 ```

--- a/scripts/unseal.sh
+++ b/scripts/unseal.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+unseal_key="$1"
+vault_addresses=(192.168.60.10 192.168.60.20 192.168.60.30)
+
+for ip in "${vault_addresses[@]}"; do
+  curl --header "Content-Type: application/json" \
+    --request POST \
+    --data "{\"key\":\"${unseal_key}\"}" \
+    http://"$ip":8200/v1/sys/unseal
+done


### PR DESCRIPTION
- Add defaults for `UBUNTU_VERSION` and `VAGRANT_PROVIDER`
- Update docs
- Add `unseal` shortcut


The intended purpose is to simplify the subsequent unseals or unseal the other 2 Vault servers

```
VAULT_UNSEAL_KEY=<vault-unseal-key> make unseal
```